### PR TITLE
Fix wedding homepage mobile navigation layout: remove column stacking

### DIFF
--- a/views/wedding.html
+++ b/views/wedding.html
@@ -160,15 +160,6 @@
                 font-size: 2rem;
             }
 
-            nav ul {
-                flex-direction: column;
-                gap: 1rem;
-            }
-
-            nav a {
-                display: block;
-                text-align: center;
-            }
         }
     </style>
 </head>


### PR DESCRIPTION
Remove mobile-specific CSS that forced navigation buttons into a vertical column layout on the main wedding page. This ensures consistent horizontal navigation across all wedding pages on mobile devices.

🤖 Generated with [Claude Code](https://claude.ai/code)